### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@0.2.1
+  python: circleci/python@1.4.0
 
 jobs:
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
       - python/install-deps
       - python/save-cache
       - run:
-          command: ./manage.py test
-          name: Test
+          command: python -m compileall modules
+          name: Test that modules compile
 
 workflows:
   main:


### PR DESCRIPTION
Add a simple test that compiles the files in modules directory and bumps the circleci/python orb version.